### PR TITLE
Allow user style-sheet to be specified for integration test cases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,7 +21,6 @@ build_debug/
 *.pyc
 toolboxes/core/core_defines.h
 prod/
-external/
 test/integration/test_cases.txt
 *.h5
 tags

--- a/apps/gadgetron/connection/stream/PureDistributed.h
+++ b/apps/gadgetron/connection/stream/PureDistributed.h
@@ -40,8 +40,8 @@ namespace Gadgetron::Server::Connection::Stream {
         using Job = std::future<Core::Message>;
         using Queue = Core::MPMCChannel<Job>;
 
-        void process_outbound(Core::GenericInputChannel, Queue &);
-        void process_inbound(Core::OutputChannel, Queue &);
+        void process_outbound(Core::GenericInputChannel, std::shared_ptr<Queue>);
+        void process_inbound(Core::OutputChannel, std::shared_ptr<Queue>);
 
         std::shared_ptr<Serialization> serialization;
         std::shared_ptr<Configuration> configuration;

--- a/apps/gadgetron/connection/stream/common/Discovery.cpp
+++ b/apps/gadgetron/connection/stream/common/Discovery.cpp
@@ -70,13 +70,22 @@ namespace Gadgetron::Server::Connection::Stream {
         auto worker_discovery_command = std::getenv("GADGETRON_REMOTE_WORKER_COMMAND");
         if (!worker_discovery_command) return std::vector<Address>{};
 
+        GDEBUG_STREAM("Worker discovery command: " << worker_discovery_command);
+
+        std::error_code error_code;
         std::future<std::string> output;
         boost::process::system(
                 worker_discovery_command,
                 boost::process::std_out > output,
                 boost::process::std_err > boost::process::null,
-                boost::asio::io_service{}
+                boost::asio::io_service{},
+                error_code
         );
+
+        if (error_code) {
+            GWARN_STREAM("Failed executing remote worker command: " << error_code.message());
+            return std::vector<Address>();
+        }
 
         return parse_remote_workers(output.get());
     }

--- a/apps/gadgetron/connection/stream/common/External.cpp
+++ b/apps/gadgetron/connection/stream/common/External.cpp
@@ -4,6 +4,8 @@
 
 #include <boost/asio.hpp>
 
+#include "system_info.h"
+
 #include "connection/SocketStreamBuf.h"
 #include "log.h"
 
@@ -53,7 +55,7 @@ namespace Gadgetron::Server::Connection::Stream {
 
         boost::asio::io_service service;
         boost::asio::ip::tcp::endpoint peer;
-        boost::asio::ip::tcp::endpoint local(boost::asio::ip::tcp::v6(), port);
+        boost::asio::ip::tcp::endpoint local(Gadgetron::Server::Info::tcp_protocol(), port);
         boost::asio::ip::tcp::acceptor acceptor(service, local);
 
         auto socket = std::make_unique<boost::asio::ip::tcp::socket>(service);

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -110,7 +110,7 @@ jobs:
   - script: |
         set -e
         fullImageName="$(AcrRegistryAddress)/$(AcrRegistryName)/$(imageName):$(build.BuildNumber)"
-        docker run --gpus all -v $(pwd)/testdata:/opt/code/gadgetron/test/integration/data --rm $fullImageName /bin/bash -c "cd /opt/code/gadgetron/test/integration/ && ./run_tests.py cases/*"
+        docker run --gpus all -v $(pwd)/testdata:/opt/code/gadgetron/test/integration/data --rm $fullImageName /bin/bash -c "cd /opt/code/gadgetron/test/integration/ && ./run_tests.py --echo-log-on-failure --timeout=600 cases/*"
     displayName: "Run integration tests"
 
 - job:

--- a/core/io/from_string.cpp
+++ b/core/io/from_string.cpp
@@ -37,6 +37,13 @@ void Gadgetron::Core::IO::from_string(const std::string& str, bool& val) { from_
 void Gadgetron::Core::IO::from_string(const std::string& str, std::vector<long long>& val) { from_string_impl(str,val);}
 void Gadgetron::Core::IO::from_string(const std::string& str, std::vector<double>& val) { from_string_impl(str,val);}
 void Gadgetron::Core::IO::from_string(const std::string& str, std::vector<bool>& val) { from_string_impl(str,val);}
-
+void Gadgetron::Core::IO::from_string(const std::string& str, std::vector<std::string>& val) { 
+    std::stringstream stream(str);
+    while(stream.good()){
+        std::string phrase;
+        stream >> phrase;
+        val.emplace_back(std::move(phrase));
+    }
+}
 
 

--- a/core/io/from_string.h
+++ b/core/io/from_string.h
@@ -5,7 +5,11 @@
 #include <sstream>
 #include <string>
 #include <vector>
+#include <set>
+
 namespace Gadgetron::Core::IO {
+
+   template <class T> T from_string(const std::string& str);    
 
     void from_string(const std::string&, long long& val);
 
@@ -61,17 +65,27 @@ template <class T> auto from_string(const std::string& str, T& val) -> std::enab
     void from_string(const std::string&, boost::filesystem::path&);
     void from_string(const std::string&, bool&);
     void from_string(const std::string&, std::vector<bool>&);
+    void from_string(const std::string&, std::vector<std::string>&);
 
     template<class T> T from_string(const std::string& str);
 
     template <size_t N> void from_string(const std::string& str, std::bitset<N>& bset) {
         bset = std::bitset<N>(from_string<unsigned int>(str));
     }
+    
+    template<class T> auto from_string(const std::string& str, std::set<T>& set) -> decltype(from_string<std::vector<T>>(str),void()) {
+        auto vec = from_string<std::vector<T>>(str);
+        set = std::set<T>(vec.begin(),vec.end());
+    } 
+
+
 
     template <class T> T from_string(const std::string& str) {
         T val;
         from_string(str, val);
         return val;
     }
+
+      
 
 }

--- a/gadgets/cmr/CmrRealTimeLAXCineAIAnalysisGadget.cpp
+++ b/gadgets/cmr/CmrRealTimeLAXCineAIAnalysisGadget.cpp
@@ -356,6 +356,9 @@ namespace Gadgetron {
             size_t new_RO = (size_t)(FOV_RO / pixel_size + 0.5);
             size_t new_E1 = (size_t)(FOV_E1 / pixel_size + 0.5);
 
+            if (new_RO % 2 == 1) new_RO++;
+            if (new_E1 % 2 == 1) new_E1++;
+
             std::vector<size_t> dim2D_out(2);
             dim2D_out[0] = new_RO;
             dim2D_out[1] = new_E1;

--- a/gadgets/mri_core/AcquisitionAccumulateTriggerGadget.h
+++ b/gadgets/mri_core/AcquisitionAccumulateTriggerGadget.h
@@ -43,8 +43,7 @@ namespace Gadgetron {
         NODE_PROPERTY(sorting_dimension, TriggerDimension, "Dimension to trigger on", TriggerDimension::none);
 
         NODE_PROPERTY(n_acquisitions_before_trigger, unsigned long, "Number of acquisition before first trigger", 40);
-        NODE_PROPERTY(
-            n_acquisitions_before_ongoing_trigger, unsigned long, "Number of acquisition before ongoing triggers", 40);
+        NODE_PROPERTY(n_acquisitions_before_ongoing_trigger, unsigned long, "Number of acquisition before ongoing triggers", 40);
 
         size_t trigger_events = 0;
     private:

--- a/gadgets/mri_core/GenericImageReconGadget.cpp
+++ b/gadgets/mri_core/GenericImageReconGadget.cpp
@@ -1590,7 +1590,7 @@ namespace Gadgetron {
                                     for (cha = 0; cha < CHA; cha++)
                                     {
                                         hoMRImage<ValueType, 2>* pImage = &images(cha, slc, con, phs, rep, set, ave);
-                                        if (pImage != NULL)
+                                        if (pImage != NULL && pImage->get_number_of_elements()>0)
                                         {
                                             T v = Gadgetron::nrm2(*pImage);
                                             if (v < FLT_EPSILON) continue; // do not send out empty image
@@ -1747,7 +1747,7 @@ namespace Gadgetron {
                                     for (cha = 0; cha < CHA; cha++)
                                     {
                                         hoMRImage<ValueType, 2>* pImage = &images(cha, slc, con, phs, rep, set, ave);
-                                        if (pImage != NULL)
+                                        if (pImage != NULL && pImage->get_number_of_elements() > 0)
                                         {
                                             T v = Gadgetron::nrm2(*pImage);
                                             if (v < FLT_EPSILON) continue; // do not send out empty image
@@ -1883,7 +1883,7 @@ namespace Gadgetron {
                                     for (cha = 0; cha < CHA; cha++)
                                     {
                                         hoMRImage<ValueType, 3>* pImage = &images(cha, slc, con, phs, rep, set, ave);
-                                        if (pImage != NULL)
+                                        if (pImage != NULL && pImage->get_number_of_elements()>0)
                                         {
                                             T v = Gadgetron::nrm2(*pImage);
                                             if (v < FLT_EPSILON) continue; // do not send out empty image
@@ -2039,7 +2039,7 @@ namespace Gadgetron {
                                     for (cha = 0; cha < CHA; cha++)
                                     {
                                         hoMRImage<ValueType, 3>* pImage = &images(cha, slc, con, phs, rep, set, ave);
-                                        if (pImage != NULL)
+                                        if (pImage != NULL && pImage->get_number_of_elements() > 0)
                                         {
                                             T v = Gadgetron::nrm2(*pImage);
                                             if (v < FLT_EPSILON) continue; // do not send out empty image

--- a/gadgets/mri_core/GenericReconCartesianGrappaGadget.cpp
+++ b/gadgets/mri_core/GenericReconCartesianGrappaGadget.cpp
@@ -205,20 +205,6 @@ namespace Gadgetron {
                 recon_obj_[e].recon_res_.acq_headers_ = recon_bit_->rbit_[e].data_.headers_;
 
                 // ---------------------------------------------------------------
-
-                if (!debug_folder_full_path_.empty()) {
-                    this->gt_exporter_.export_array_complex(recon_obj_[e].recon_res_.data_,
-                                                            debug_folder_full_path_ + "recon_res" + os.str());
-                }
-
-                if (perform_timing.value()) {
-                    gt_timer_.start("GenericReconCartesianGrappaGadget::send_out_image_array");
-                }
-                this->send_out_image_array(recon_obj_[e].recon_res_, e,
-                                           image_series.value() + ((int) e + 1), GADGETRON_IMAGE_REGULAR);
-                if (perform_timing.value()) { gt_timer_.stop(); }
-
-                // ---------------------------------------------------------------
                 if (send_out_gfactor.value() && recon_obj_[e].gfactor_.get_number_of_elements() > 0 &&
                     (acceFactorE1_[e] * acceFactorE2_[e] > 1)) {
                     IsmrmrdImageArray res;
@@ -268,6 +254,20 @@ namespace Gadgetron {
                         if (perform_timing.value()) { gt_timer_.stop(); }
                     }
                 }
+
+                // ---------------------------------------------------------------
+
+                if (!debug_folder_full_path_.empty()) {
+                    this->gt_exporter_.export_array_complex(recon_obj_[e].recon_res_.data_,
+                        debug_folder_full_path_ + "recon_res" + os.str());
+                }
+
+                if (perform_timing.value()) {
+                    gt_timer_.start("GenericReconCartesianGrappaGadget::send_out_image_array");
+                }
+                this->send_out_image_array(recon_obj_[e].recon_res_, e,
+                    image_series.value() + ((int)e + 1), GADGETRON_IMAGE_REGULAR);
+                if (perform_timing.value()) { gt_timer_.stop(); }
             }
 
             recon_obj_[e].recon_res_.data_.clear();

--- a/gadgets/mri_core/IsmrmrdDumpGadget.cpp
+++ b/gadgets/mri_core/IsmrmrdDumpGadget.cpp
@@ -2,12 +2,14 @@
 #include <iomanip>
 #include <boost/filesystem.hpp>
 #include "network_utils.h"
+#include <thread>
 
 namespace bf = boost::filesystem;
 
+
 namespace Gadgetron
 {
-    std::string get_date_time_string()
+    static std::string get_date_time_string()
     {
         time_t rawtime;
         struct tm * timeinfo;
@@ -27,133 +29,88 @@ namespace Gadgetron
 
         return ret;
     }
+    bool IsmrmrdDumpGadget::is_ip_on_blacklist() const {
+        if (ip_no_data_saving.empty()){
+            return false; 
+        }
+        GDEBUG_STREAM("IsmrmrdDumpGadget, find pre-set ip for no-data-saving : " << ip_no_data_saving.size() << " [ ");
+        for (auto ip : ip_no_data_saving)
+                GDEBUG_STREAM(ip);
+        GDEBUG_STREAM(" ] ");
 
-    IsmrmrdDumpGadget::IsmrmrdDumpGadget() : BaseClass(), first_call_(true), save_ismrmrd_data_(true)
-    {
-    }
-
-    IsmrmrdDumpGadget::~IsmrmrdDumpGadget()
-    {
-    }
-
-    int IsmrmrdDumpGadget::process_config(ACE_Message_Block* mb)
-    {
-
-        ISMRMRD::deserialize(mb->rd_ptr(), ismrmrd_header_);
-        ismrmrd_xml_ = std::string(mb->rd_ptr());
-
-        // if ip_no_data_saving is set, check current ip of gadgetron server
-        if (!this->ip_no_data_saving.value().empty())
-        {
-            std::vector<std::string> ip_list = this->ip_no_data_saving.value();
-
-            GDEBUG_STREAM("IsmrmrdDumpGadget, find pre-set ip for no-data-saving : " << ip_list.size() << " [ ");
-
-            size_t n;
-            for (n = 0; n < ip_list.size(); n++)
-            {
-                GDEBUG_STREAM(ip_list[n]);
-            }
-            GDEBUG_STREAM(" ] ");
-
-            // get current ip of gadgetron
-            std::string host_name;
-            std::vector<std::string> gt_ip_list;
-            try
-            {
-                Gadgetron::find_gadgetron_ip(host_name, gt_ip_list);
-            }
-            catch (...)
-            {
-                GERROR_STREAM("Find gadgetrion ip failed ... ");
-                gt_ip_list.clear();
-            }
+            const auto [host_name, gt_ip_list ] = Gadgetron::find_gadgetron_ip();
 
             GDEBUG_STREAM("IsmrmrdDumpGadget, find gadgetron host name : " << host_name);
 
             GDEBUG_STREAM("IsmrmrdDumpGadget, find gadgetron ip : " << gt_ip_list.size() << " [ ");
-            for (n = 0; n < gt_ip_list.size(); n++)
-            {
-                GDEBUG_STREAM(gt_ip_list[n]);
-            }
+            for (const auto & ip : gt_ip_list) 
+                GDEBUG_STREAM(ip);
             GDEBUG_STREAM(" ] ");
 
-            size_t m;
 
-            for (n = 0; n < ip_list.size(); n++)
-            {
-                for (m = 0; m < gt_ip_list.size(); m++)
-                {
-                    if (ip_list[n] == gt_ip_list[m])
-                    {
-                        this->save_ismrmrd_data_ = false;
-                        GDEBUG_STREAM("IsmrmrdDumpGadget, find matching ip pair : " << ip_list[n]);
-                        break;
-                    }
-                }
+            for (const auto & ip : gt_ip_list ){
+                if (ip_no_data_saving.count(ip)){
 
-                if (!this->save_ismrmrd_data_)
-                {
-                    break;
+                    GDEBUG_STREAM("IsmrmrdDumpGadget, find matching ip pair : " << ip);
+                    return true;
                 }
             }
-        }
+            return false;
+       }
 
-        if (this->save_ismrmrd_data_)
+
+    
+
+    IsmrmrdDumpGadget::IsmrmrdDumpGadget(const Core::Context& context, const Core::GadgetProperties& props ) : Core::ChannelGadget<Core::variant<Core::Acquisition,Core::Waveform>>(context, props), save_ismrmrd_data_(!is_ip_on_blacklist()) {
+        if (save_ismrmrd_data_)
         {
-            boost::filesystem::path p(folder.value());
-
-            if (!exists(p))
+            if (!exists(folder ))
             {
                 try
                 {
-                    boost::filesystem::create_directory(p);
+                    boost::filesystem::create_directory(folder );
                 }
                 catch (...)
                 {
-                    GERROR("Error caught trying to create folder %s\n", folder.value().c_str());
-                    return GADGET_FAIL;
+                    std::stringstream stream("Error caught trying to create folder ");
+                    stream << folder;
+                    GADGET_THROW(stream.str());
                 }
             }
             else
             {
-                if (!is_directory(p))
+                if (!is_directory(folder ))
                 {
-                    GERROR("Specified path is not a directory\n");
-                    return GADGET_FAIL;
+                    GADGET_THROW("Specified path is not a directory\n");
                 }
             }
         }
-
-        return GADGET_OK;
     }
 
-    int IsmrmrdDumpGadget::create_ismrmrd_dataset()
+    ISMRMRD::Dataset IsmrmrdDumpGadget::create_ismrmrd_dataset() const 
     {
-        try {
             std::string measurement_id = "";
             std::string ismrmrd_filename = "";
 
-            if (ismrmrd_header_.measurementInformation)
+            if (header.measurementInformation)
             {
-                if (ismrmrd_header_.measurementInformation->measurementID)
+                if (header.measurementInformation->measurementID)
                 {
-                    measurement_id = *ismrmrd_header_.measurementInformation->measurementID;
+                    measurement_id = *header.measurementInformation->measurementID;
                 }
             }
 
             GDEBUG("Measurement ID: %s\n", measurement_id.c_str());
 
-            boost::filesystem::path p(folder.value());
 
-            if (file_prefix.value().empty())
+            if (file_prefix.empty())
             {
                 // try to use the protocol name
-                if (ismrmrd_header_.measurementInformation.is_present())
+                if (header.measurementInformation.is_present())
                 {
-                    if (ismrmrd_header_.measurementInformation.get().protocolName.is_present())
+                    if (header.measurementInformation.get().protocolName.is_present())
                     {
-                        ismrmrd_filename = ismrmrd_header_.measurementInformation.get().protocolName.get();
+                        ismrmrd_filename = header.measurementInformation.get().protocolName.get();
 
                         for (std::string::size_type i = 0; (i = ismrmrd_filename.find(" ", i)) != std::string::npos;)
                         {
@@ -175,27 +132,27 @@ namespace Gadgetron
             }
             else
             {
-                ismrmrd_filename = file_prefix.value();
+                ismrmrd_filename = file_prefix;
             }
 
             ismrmrd_filename.append("_");
             ismrmrd_filename.append(measurement_id);
 
             std::string study_date, study_time;
-            if (ismrmrd_header_.studyInformation)
+            if (header.studyInformation)
             {
-                if (ismrmrd_header_.studyInformation->studyDate)
+                if (header.studyInformation->studyDate)
                 {
-                    study_date = *ismrmrd_header_.studyInformation->studyDate;
+                    study_date = *header.studyInformation->studyDate;
 
                     std::string d(study_date);
                     d.erase(std::remove(d.begin(), d.end(), '-'), d.end());
                     study_date = d;
                 }
 
-                if (ismrmrd_header_.studyInformation->studyTime)
+                if (header.studyInformation->studyTime)
                 {
-                    study_time = *ismrmrd_header_.studyInformation->studyTime;
+                    study_time = *header.studyInformation->studyTime;
 
                     std::string d(study_time);
                     d.erase(std::remove(d.begin(), d.end(), ':'), d.end());
@@ -219,189 +176,87 @@ namespace Gadgetron
 
             ismrmrd_filename.append(".h5");
 
-            p /= ismrmrd_filename;
+            auto filepath = folder / ismrmrd_filename;
 
-            ismrmrd_filename = p.string();
+            ismrmrd_filename = filepath.string();
             GDEBUG_STREAM("KSpace dump file name : " << ismrmrd_filename);
 
-            ismrmrd_dataset_ = boost::shared_ptr<ISMRMRD::Dataset>(new ISMRMRD::Dataset(ismrmrd_filename.c_str(), "dataset", true));
-        }
-        catch (...)
-        {
-            GERROR_STREAM("Error happened in IsmrmrdDumpGadget::create_ismrmrd_dataset(...) ... ");
-            return GADGET_FAIL;
+            return ISMRMRD::Dataset(ismrmrd_filename.c_str(), "dataset", true);
         }
 
-        return GADGET_OK;
+    static void append_to_dataset(const Core::Acquisition& acq, ISMRMRD::Dataset& dataset){
+        const auto& [acq_head, data, traj]  = acq;         
+                   ISMRMRD::Acquisition ismrmrd_acq;
+                   ismrmrd_acq.setHead(acq_head);
+                   ismrmrd_acq.setData(const_cast<std::complex<float>*>(data.data()));
+                   if (traj) ismrmrd_acq.setTraj(const_cast<float*>(traj->data()));
+                   dataset.appendAcquisition(ismrmrd_acq);
+    }
+    static void append_to_dataset(const Core::Waveform& acq, ISMRMRD::Dataset& dataset){
+        const auto& [wav_head, data ]  = acq;         
+                   ISMRMRD::Waveform ismrmrd_wav(wav_head.number_of_samples,wav_head.channels);
+                   ismrmrd_wav.head = wav_head;
+                   std::copy(data.begin(),data.end(),ismrmrd_wav.data);
+                   dataset.appendWaveform(ismrmrd_wav);
     }
 
-    int IsmrmrdDumpGadget::process(GadgetContainerMessage<ISMRMRD::AcquisitionHeader>* m1)
+
+    void IsmrmrdDumpGadget::process(Core::InputChannel<Core::variant<Core::Acquisition,Core::Waveform>>& input, Core::OutputChannel& output)
     {
-        if (first_call_)
-        {
-            if (this->save_ismrmrd_data_)
-            {
-                this->create_ismrmrd_dataset();
 
-                try
-                {
-                    ismrmrd_dataset_->writeHeader(ismrmrd_xml_);
+        auto is_valid_type =[this](const auto& item){ return this->pass_waveform_downstream || std::holds_alternative<Core::Acquisition>(item);};
+
+        auto move_if = [](auto& input, auto& output, const auto& pred ){
+            for (auto item : input ){
+                if (pred(item)){
+                    output.push(std::move(item));
                 }
-                catch (...)
-                {
-                    GDEBUG("Failed to write XML header to HDF file\n");
-                    return GADGET_FAIL;
-                }
-
-                GDEBUG_STREAM("IsmrmrdDumpGadget, save ismrmrd xml header ... ");
             }
-            else
-            {
-                GDEBUG_STREAM("IsmrmrdDumpGadget, do NOT save ismrmrd data ... ");
-            }
+        };
 
-            first_call_ = false;
+        if (!save_ismrmrd_data_) {
+            GDEBUG_STREAM("IsmrmrdDumpGadget, do NOT save ismrmrd data ... ");
+            move_if(input,output, is_valid_type );
+            return;
         }
 
-        if (this->save_ismrmrd_data_ && !this->save_xml_header_only.value())
+        auto dataset = create_ismrmrd_dataset();
+
         {
-            ISMRMRD::Acquisition ismrmrd_acq;
-            ismrmrd_acq.setHead(*m1->getObjectPtr());
-
-            GadgetContainerMessage< hoNDArray< std::complex<float> > >* m2 = AsContainerMessage< hoNDArray< std::complex<float> > >(m1->cont());
-            if (!m2)
-            {
-                GDEBUG("Error casting acquisition data package");
-                return GADGET_FAIL;
-            }
-
-            memcpy((void *)ismrmrd_acq.getDataPtr(), m2->getObjectPtr()->get_data_ptr(), sizeof(float)*m2->getObjectPtr()->get_number_of_elements() * 2);
-
-            if (m2->cont())
-            {
-                //Write trajectory
-                if (ismrmrd_acq.trajectory_dimensions() == 0)
-                {
-                    GDEBUG("Malformed dataset. Trajectory attached but trajectory dimensions == 0\n");
-                    return GADGET_FAIL;
-                }
-
-                GadgetContainerMessage< hoNDArray<float> >* m3 = AsContainerMessage< hoNDArray<float> >(m2->cont());
-
-                if (!m3)
-                {
-                    GDEBUG("Error casting trajectory data package");
-                    return GADGET_FAIL;
-                }
-
-                memcpy((void *)ismrmrd_acq.getTrajPtr(), m3->getObjectPtr()->get_data_ptr(),
-                    sizeof(float)*m3->getObjectPtr()->get_number_of_elements());
-            }
-            else
-            {
-                if (ismrmrd_acq.trajectory_dimensions() != 0)
-                {
-                    GDEBUG("Malformed dataset. Trajectory dimensions not zero but no trajectory attached\n");
-                    return GADGET_FAIL;
-                }
-            }
-
-            {
-                try
-                {
-                    ismrmrd_dataset_->appendAcquisition(ismrmrd_acq);
-                }
-                catch (...)
-                {
-                    GDEBUG("Error appending ISMRMRD Dataset\n");
-                    return GADGET_FAIL;
-                }
-            }
+           auto stream = std::stringstream();
+           ISMRMRD::serialize(header,stream);
+           dataset.writeHeader(stream.str());
+            GDEBUG_STREAM("IsmrmrdDumpGadget, save ismrmrd xml header ... ");
         }
 
-        //It is enough to put the first one, since they are linked
-        if (this->next()->putq(m1) == -1)
-        {
-            m1->release();
-            GERROR("IsmrmrdDumpGadget::process, passing data on to next gadget");
-            return -1;
+        if (save_xml_header_only){
+            GDEBUG_STREAM("Only saving header");
+            move_if(input,output, is_valid_type);
+            return;
         }
 
-        return 0;
+        Core::MPMCChannel<Core::variant<Core::Acquisition,Core::Waveform>> data_buffer;
+
+        auto save_thread = std::thread([&data_buffer,&dataset ](){
+            try {
+                for (;;) {
+                    Core::visit([&dataset](const auto& item) { append_to_dataset(item, dataset); }, data_buffer.pop());
+                }
+            } catch (const Core::ChannelClosed& closed) {              
+            }
+        });
+
+        for (auto item : input){
+            data_buffer.push(item);
+            if (is_valid_type(item))
+                output.push(std::move(item));
+        }
+        data_buffer.close();
+
+        save_thread.join();
     }
+    GADGETRON_GADGET_EXPORT(IsmrmrdDumpGadget);
 
-    int IsmrmrdDumpGadget::process(GadgetContainerMessage<ISMRMRD::WaveformHeader>* m1)
-    {
-        if (first_call_)
-        {
-            if (this->save_ismrmrd_data_)
-            {
-                this->create_ismrmrd_dataset();
 
-                try
-                {
-                    ismrmrd_dataset_->writeHeader(ismrmrd_xml_);
-                }
-                catch (...)
-                {
-                    GDEBUG("Failed to write XML header to HDF file\n");
-                    return GADGET_FAIL;
-                }
 
-                GDEBUG_STREAM("IsmrmrdDumpGadget, first call is on waveform, save ismrmrd xml header ... ");
-            }
-            else
-            {
-                GDEBUG_STREAM("IsmrmrdDumpGadget, first call is on waveform, do NOT save ismrmrd data ... ");
-            }
-
-            first_call_ = false;
-        }
-
-        if (this->save_ismrmrd_data_ && !this->save_xml_header_only.value())
-        {
-            ISMRMRD::Waveform ismrmrd_wav;
-            ismrmrd_wav.head = *m1->getObjectPtr();
-
-            GadgetContainerMessage< hoNDArray< uint32_t > >* m2 = AsContainerMessage< hoNDArray< uint32_t > >(m1->cont());
-            if (!m2)
-            {
-                GDEBUG("Error casting waveform data package");
-                return GADGET_FAIL;
-            }
-
-            ismrmrd_wav.data = m2->getObjectPtr()->begin();
-
-            try
-            {
-                ismrmrd_dataset_->appendWaveform(ismrmrd_wav);
-            }
-            catch (...)
-            {
-                GDEBUG("Error appending ISMRMRD Waveform\n");
-                return GADGET_FAIL;
-            }
-
-            ismrmrd_wav.data = NULL;
-        }
-
-        // TODO: remove this check
-        if(this->pass_waveform_downstream.value())
-        {
-            if (this->next()->putq(m1) == -1)
-            {
-                m1->release();
-                GERROR("IsmrmrdDumpGadget::process, passing waveform on to next gadget");
-                return -1;
-            }
-        }
-        else
-        {
-            m1->release();
-        }
-
-        return 0;
-    }
-
-    GADGET_FACTORY_DECLARE(IsmrmrdDumpGadget)
 }

--- a/gadgets/mri_core/IsmrmrdDumpGadget.h
+++ b/gadgets/mri_core/IsmrmrdDumpGadget.h
@@ -1,69 +1,59 @@
-#ifndef ISMRMRDDUMPGADGET_H
-#define ISMRMRDDUMPGADGET_H
-
-#include "Gadget.h"
+#pragma once 
+#include "Node.h"
+#include "Types.h"
 #include "hoNDArray.h"
-#include "gadgetron_mricore_export.h"
+#include "io/from_string.h"
 
 #include <ismrmrd/ismrmrd.h>
 #include <ismrmrd/dataset.h>
 #include <ismrmrd/xml.h>
 #include <ismrmrd/waveform.h>
+#include <set>
 
 #include <complex>
 
-namespace Gadgetron {
 
-    class EXPORTGADGETSMRICORE IsmrmrdDumpGadget :
-        public Gadgetron::Gadget1Of2<ISMRMRD::AcquisitionHeader, ISMRMRD::WaveformHeader >
+
+namespace Gadgetron {
+       class IsmrmrdDumpGadget : public Core::ChannelGadget<Core::variant<Core::Acquisition, Core::Waveform>>
     {
     public:
-        typedef Gadgetron::Gadget1Of2<ISMRMRD::AcquisitionHeader, ISMRMRD::WaveformHeader > BaseClass;
-
-        GADGET_DECLARE(IsmrmrdDumpGadget);
-
-        IsmrmrdDumpGadget();
-        virtual ~IsmrmrdDumpGadget();
+      
+        IsmrmrdDumpGadget(const Core::Context& context, const Core::GadgetProperties& props ); 
+        virtual ~IsmrmrdDumpGadget() = default;
 
     protected:
 
 #ifndef WIN32
-        GADGET_PROPERTY(folder, std::string, "Folder for save dump file", "/tmp/gadgetron_data");
+        NODE_PROPERTY(folder, boost::filesystem::path, "Folder for save dump file", "/tmp/gadgetron_data");
 #else
-        GADGET_PROPERTY(folder, std::string, "Folder for save dump file", "c:/temp/gadgetron_data");
+        NODE_PROPERTY(folder, boost::filesystem::path, "Folder for save dump file", "c:/temp/gadgetron_data");
 #endif // WIN32
 
-        GADGET_PROPERTY(file_prefix, std::string, "Prefix for dump file", "ISMRMRD_DUMP");
+        NODE_PROPERTY(file_prefix, std::string, "Prefix for dump file", "ISMRMRD_DUMP");
 
         // In some cases, data cannot be saved to a gadgetron server
         // if gadgetron ip equals to these preset ips, do not save data
-        GadgetProperty<std::vector<std::string>, GadgetPropertyLimitsNoLimits<std::vector<std::string> > > ip_no_data_saving{ "ip_no_data_saving",
-            "std::string",
-            "If gadgetrion IP equals to this ip, do not save data",
-            this,
-            { "192.168.2.2", "192.168.56.2" },
-            GadgetPropertyLimitsNoLimits<std::vector<std::string> >() };
-
+        NODE_PROPERTY(ip_no_data_saving, std::set<std::string>, "If gadgetrion IP equals to this ip, do not save data",std::set<std::string>({ "192.168.2.2", "192.168.56.2" }));
         // if true, only save the xml header
-        GADGET_PROPERTY(save_xml_header_only, bool, "If true, only save the xml header", false);
+        NODE_PROPERTY(save_xml_header_only, bool, "If true, only save the xml header", false);
 
         // since the support to waveform is not fully implemented, this option is added for not passing waveform downstream
         // TODO: remove this option
-        GADGET_PROPERTY(pass_waveform_downstream, bool, "If true, waveform data is passed downstream", false);
+        NODE_PROPERTY(pass_waveform_downstream, bool, "If true, waveform data is passed downstream", false);
 
-        int process_config(ACE_Message_Block* mb) override;
-        int process(GadgetContainerMessage<ISMRMRD::AcquisitionHeader>* m1) override ;
-        int process(GadgetContainerMessage<ISMRMRD::WaveformHeader>* m1) override ;
+
+        void process(Core::InputChannel<Core::variant<Core::Acquisition,Core::Waveform>>& input, Core::OutputChannel& output) override;
+
 
     private:
 
-        bool first_call_;
-        bool save_ismrmrd_data_;
-        ISMRMRD::IsmrmrdHeader ismrmrd_header_;
-        std::string ismrmrd_xml_;
-        boost::shared_ptr<ISMRMRD::Dataset>  ismrmrd_dataset_;
+        const bool save_ismrmrd_data_;
 
-        int create_ismrmrd_dataset();
+        ISMRMRD::Dataset create_ismrmrd_dataset() const;
+        bool  is_ip_on_blacklist() const ; 
     };
+
+
+
 }
-#endif //ISMRMRDDUMPGADGET_H

--- a/gadgets/mri_core/NoiseAdjustGadget.cpp
+++ b/gadgets/mri_core/NoiseAdjustGadget.cpp
@@ -407,7 +407,6 @@ namespace Gadgetron {
 
     template <class NH>
     NoiseAdjustGadget::NoiseHandler NoiseAdjustGadget::handle_acquisition(NH nh, Core::Acquisition& acq) const {
-        GDEBUG_STREAM("Noone with type " << typeid(nh).name() <<  " handles dem acquisitions");
         return std::move(nh);
     };
 

--- a/gadgets/mri_core/config/ismrmrd_dump.xml
+++ b/gadgets/mri_core/config/ismrmrd_dump.xml
@@ -16,8 +16,6 @@
     <name>IsmrmrdDump</name>
     <dll>gadgetron_mricore</dll>
     <classname>IsmrmrdDumpGadget</classname>
-    <property><name>file_prefix</name><value></value></property>
-    <property><name>folder</name><value></value></property>
     <property><name>save_xml_header_only</name><value>false</value></property>
   </gadget>
 

--- a/test/integration/run_gadgetron_test.py
+++ b/test/integration/run_gadgetron_test.py
@@ -43,12 +43,15 @@ Skipped = "Skipped", 2
 
 def siemens_to_ismrmrd(echo_handler, *, input, output, parameters, schema, measurement, flag=None):
 
-    command = ["siemens_to_ismrmrd", "-X",
-               "-f", input,
-               "-m", parameters,
-               "-x", schema,
-               "-o", output,
-               "-z", measurement] + ([flag] if flag else [])
+    command = (
+                ["siemens_to_ismrmrd", "-X",
+                 "-f", input,
+                 "-m", parameters ] +
+               (["-x", schema,] if not (flag and flag[:18] == '--user-stylesheet=') else []) +
+                ["-o", output,
+                 "-z", measurement] +
+                ([flag] if flag else [])
+              )
 
     echo_handler(command)
     subprocess.run(command,

--- a/toolboxes/cmr/cmr_image_container_util.cpp
+++ b/toolboxes/cmr/cmr_image_container_util.cpp
@@ -25,7 +25,7 @@ namespace Gadgetron
 
             for (slc = 0; slc < SLC; slc++)
             {
-#pragma parallel for default(none) shared(PHS, input, dim_out, output) private(phs)
+#pragma omp parallel for default(none) shared(PHS, input, dim_out, output, slc) private(phs)
                 for (phs = 0; phs < PHS; phs++)
                 {
                     ImageType& a_image = const_cast<ImageType&>(input(slc, phs));
@@ -101,7 +101,7 @@ namespace Gadgetron
 
             for (slc = 0; slc < SLC; slc++)
             {
-#pragma parallel for default(none) shared(PHS, input, dim_out, output) private(phs)
+#pragma omp parallel for default(none) shared(PHS, input, output, slc, scale_ratio) private(phs)
                 for (phs = 0; phs < PHS; phs++)
                 {
                     ImageType& a_image = const_cast<ImageType&>(input(slc, phs));

--- a/toolboxes/core/cpu/hostutils/network_utils.cpp
+++ b/toolboxes/core/cpu/hostutils/network_utils.cpp
@@ -7,12 +7,15 @@
 #include <cmath>
 #include <cstdlib>
 #include "log.h"
+#include <boost/process.hpp>
+#include <regex>
 
 namespace Gadgetron {
 
     void find_gadgetron_ip(std::string& host_name, std::vector<std::string>& ip_list)
     {
         try
+        
         {
             boost::asio::io_service io_service;
             boost::asio::ip::tcp::resolver resolver(io_service);
@@ -31,23 +34,25 @@ namespace Gadgetron {
                 iter++;
             }
 #else
-            FILE * fp = popen("ifconfig", "r");
-            if (fp) {
-                char *p = NULL, *e; size_t n;
-                while ((getline(&p, &n, fp) > 0) && p) {
-                    if (p = strstr(p, "inet ")) {
-                        p += 5;
-                        if (p = strchr(p, ':')) {
-                            ++p;
-                            if (e = strchr(p, ' ')) {
-                                *e = '\0';
-                                ip_list.push_back(std::string(p));
-                            }
-                        }
-                    }
-                }
+
+            namespace bp = boost::process;
+
+            bp::ipstream stream;
+            auto c = bp::child(
+                    bp::search_path("ifconfig"),
+                    bp::std_out > stream
+            );
+
+            auto reg = std::regex(R"(inet\s+(\S+))");
+            std::string line;
+            const std::string inet = "inet ";
+            while(std::getline(stream, line)){
+                std::smatch s;
+                if (!std::regex_search(line,s,reg)) continue;
+
+                ip_list.emplace_back(s[1]);
+
             }
-            pclose(fp);
 #endif // WIN32
         }
         catch (...)
@@ -56,4 +61,20 @@ namespace Gadgetron {
         }
     }
 
+
+    IP_list find_gadgetron_ip(){
+        auto ip_list = IP_list{};
+
+        try {
+            find_gadgetron_ip(ip_list.host_name,ip_list.ip_list);
+        } 
+        catch (...){
+            GERROR("Errors in find_gadgetron_ip() \n");
+        }
+
+        return ip_list;
+
+
+
+    }
 }

--- a/toolboxes/core/cpu/hostutils/network_utils.h
+++ b/toolboxes/core/cpu/hostutils/network_utils.h
@@ -1,10 +1,16 @@
 #pragma once
-#include "hostutils_export.h"
 #include <string>
 #include <vector>
 
 namespace Gadgetron {
 
     /// find the ip of current gadgetron server
-    EXPORTHOSTUTILS void find_gadgetron_ip(std::string& host_name, std::vector<std::string>& ip_list);
+    void find_gadgetron_ip(std::string& host_name, std::vector<std::string>& ip_list);
+
+    struct IP_list{
+        std::string host_name;
+        std::vector<std::string> ip_list;
+    };
+
+    IP_list find_gadgetron_ip();
 }

--- a/toolboxes/mri_core/mri_core_def.h
+++ b/toolboxes/mri_core/mri_core_def.h
@@ -128,7 +128,7 @@ namespace Gadgetron
     #define GADGETRON_KEEP_IMAGE_GEOMETRY                   "Keep_image_geometry"
 
     /// instruct the client to send images to database without further processing
-    #define GADGETRON_DIRECT_IMGAE_SEND                     "Gadgetron_ImageDirectSend"
+    #define GADGETRON_DIRECT_IMAGE_SEND                     "Gadgetron_ImageDirectSend"
 
     /// data flow tag
     /// if this flag is set to be 1 for a image, the image is immediately passed to the next gadget

--- a/toolboxes/plplot/GtPLplot.cpp
+++ b/toolboxes/plplot/GtPLplot.cpp
@@ -4,21 +4,20 @@
 */
 
 #include "GtPLplot.h"
+#include <cmath>
 #include <iostream>
 #include <stack>
-#include <cmath>
 
 #include "plConfig.h"
 #include "plplot.h"
 
-namespace Gadgetron
-{
+namespace Gadgetron {
 
 // -----------------------------------------------
 
-template <typename T> 
-void findDataRange(const std::vector<hoNDArray<T> >& x, const std::vector<hoNDArray<T> >& y, T& minX, T& maxX, T& minY, T& maxY)
-{
+template <typename T>
+void findDataRange(const std::vector<hoNDArray<T>>& x, const std::vector<hoNDArray<T>>& y, T& minX, T& maxX, T& minY,
+                   T& maxY) {
     size_t n;
 
     maxY = Gadgetron::max(const_cast<hoNDArray<T>*>(&y[0]));
@@ -27,31 +26,32 @@ void findDataRange(const std::vector<hoNDArray<T> >& x, const std::vector<hoNDAr
     maxX = Gadgetron::max(const_cast<hoNDArray<T>*>(&x[0]));
     minX = Gadgetron::min(const_cast<hoNDArray<T>*>(&x[0]));
 
-    for (n = 1; n < x.size(); n++)
-    {
+    for (n = 1; n < x.size(); n++) {
         T v = Gadgetron::max(const_cast<hoNDArray<T>*>(&y[n]));
-        if (v>maxY) maxY = v;
+        if (v > maxY)
+            maxY = v;
 
         v = Gadgetron::min(const_cast<hoNDArray<T>*>(&y[n]));
-        if (v<minY) minY = v;
+        if (v < minY)
+            minY = v;
 
         v = Gadgetron::max(const_cast<hoNDArray<T>*>(&x[n]));
-        if (v>maxX) maxX = v;
+        if (v > maxX)
+            maxX = v;
 
         v = Gadgetron::min(const_cast<hoNDArray<T>*>(&x[n]));
-        if (v<minX) minX = v;
+        if (v < minX)
+            minX = v;
     }
 }
 
-void outputPlotIm(const hoNDArray<unsigned char>& im, bool trueColor, hoNDArray<float>& plotIm)
-{
+void outputPlotIm(const hoNDArray<unsigned char>& im, bool trueColor, hoNDArray<float>& plotIm) {
     size_t xsize = im.get_size(1);
     size_t ysize = im.get_size(2);
 
     plotIm.copyFrom(im);
 
-    if (trueColor)
-    {
+    if (trueColor) {
         std::vector<size_t> dim_order(3);
         dim_order[0] = 1;
         dim_order[1] = 2;
@@ -63,9 +63,7 @@ void outputPlotIm(const hoNDArray<unsigned char>& im, bool trueColor, hoNDArray<
         plotIm.create(xsize, ysize, 3);
 
         Gadgetron::permute(plotImPermuted, plotIm, dim_order);
-    }
-    else
-    {
+    } else {
         hoNDArray<float> plotIm2D;
         Gadgetron::sum_over_dimension(plotIm, plotIm2D, 0);
 
@@ -80,219 +78,210 @@ void outputPlotIm(const hoNDArray<unsigned char>& im, bool trueColor, hoNDArray<
     }
 }
 
-//0    black(default background)
-//1    red(default foreground)
-//2    yellow
-//3    green
-//4    aquamarine
-//5    pink
-//6    wheat
-//7    grey
-//8    brown
-//9    blue
-//10   BlueViolet
-//11   cyan
-//12   turquoise
-//13   magenta
-//14   salmon
-//15   white
+// 0    black(default background)
+// 1    red(default foreground)
+// 2    yellow
+// 3    green
+// 4    aquamarine
+// 5    pink
+// 6    wheat
+// 7    grey
+// 8    brown
+// 9    blue
+// 10   BlueViolet
+// 11   cyan
+// 12   turquoise
+// 13   magenta
+// 14   salmon
+// 15   white
 
-void getPlotColor(size_t n, int& color)
-{
-    switch (n%15)
-    {
-        case 0:
-            color = 15;
-            break;
+void getPlotColor(size_t n, int& color) {
+    switch (n % 15) {
+    case 0:
+        color = 15;
+        break;
 
-        case 1:
-            color = 2;
-            break;
+    case 1:
+        color = 2;
+        break;
 
-        case 2:
-            color = 3;
-            break;
+    case 2:
+        color = 3;
+        break;
 
-        case 3:
-            color = 4;
-            break;
+    case 3:
+        color = 4;
+        break;
 
-        case 5:
-            color = 6;
-            break;
+    case 5:
+        color = 6;
+        break;
 
-        case 6:
-            color = 7;
-            break;
+    case 6:
+        color = 7;
+        break;
 
-        case 7:
-            color = 8;
-            break;
+    case 7:
+        color = 8;
+        break;
 
-        case 8:
-            color = 9;
-            break;
+    case 8:
+        color = 9;
+        break;
 
-        case 9:
-            color = 10;
-            break;
+    case 9:
+        color = 10;
+        break;
 
-        case 10:
-            color = 11;
-            break;
+    case 10:
+        color = 11;
+        break;
 
-        case 11:
-            color = 12;
-            break;
+    case 11:
+        color = 12;
+        break;
 
-        case 12:
-            color = 13;
-            break;
+    case 12:
+        color = 13;
+        break;
 
-        case 13:
-            color = 14;
-            break;
+    case 13:
+        color = 14;
+        break;
 
-        case 14:
-            color = 1;
-            break;
+    case 14:
+        color = 1;
+        break;
 
-        default:
-            color = 15;
+    default:
+        color = 15;
     }
 }
 
-void getPlotGlyph(size_t n, std::string& gly)
-{
-    switch (n%26)
-    {
-        case 0:
-            gly = "#(840)"; // circle;
-            break;
+void getPlotGlyph(size_t n, std::string& gly) {
+    switch (n % 26) {
+    case 0:
+        gly = "#(840)"; // circle;
+        break;
 
-        case 1:
-            gly = "#(752)"; // *
-            break;
+    case 1:
+        gly = "#(752)"; // *
+        break;
 
-        case 2:
-            gly = "#(225)"; // +
-            break;
+    case 2:
+        gly = "#(225)"; // +
+        break;
 
-        case 3:
-            gly = "#(048)"; // x
-            break;
+    case 3:
+        gly = "#(048)"; // x
+        break;
 
-        case 5:
-            gly = "#(729)"; // .
-            break;
+    case 5:
+        gly = "#(729)"; // .
+        break;
 
-        case 6:
-            gly = "#(852)"; // triangle (up)
-            break;
+    case 6:
+        gly = "#(852)"; // triangle (up)
+        break;
 
-        case 7:
-            gly = "#(854)"; // triangle (down)
-            break;
+    case 7:
+        gly = "#(854)"; // triangle (down)
+        break;
 
-        case 8:
-            gly = "#(853)"; // triangle (left)
-            break;
+    case 8:
+        gly = "#(853)"; // triangle (left)
+        break;
 
-        case 9:
-            gly = "#(855)"; // triangle (right)
-            break;
+    case 9:
+        gly = "#(855)"; // triangle (right)
+        break;
 
-        case 10:
-            gly = "#(857)"; // flag
-            break;
+    case 10:
+        gly = "#(857)"; // flag
+        break;
 
-        case 11:
-            gly = "#(212)"; // :
-            break;
+    case 11:
+        gly = "#(212)"; // :
+        break;
 
-        case 12:
-            gly = "#(221)"; // <
-            break;
+    case 12:
+        gly = "#(221)"; // <
+        break;
 
-        case 13:
-            gly = "#(222)"; // >
-            break;
+    case 13:
+        gly = "#(222)"; // >
+        break;
 
-        case 14:
-            gly = "#(851)"; // square
-            break;
+    case 14:
+        gly = "#(851)"; // square
+        break;
 
-        case 15:
-            gly = "#(751)"; // rectangle
-            break;
+    case 15:
+        gly = "#(751)"; // rectangle
+        break;
 
-        case 16:
-            gly = "#(828)"; 
-            break;
+    case 16:
+        gly = "#(828)";
+        break;
 
-        case 17:
-            gly = "#(227)"; // x
-            break;
+    case 17:
+        gly = "#(227)"; // x
+        break;
 
-        case 18:
-            gly = "#(229)"; // .
-            break;
+    case 18:
+        gly = "#(229)"; // .
+        break;
 
-        case 19:
-            gly = "#(233)"; // #
-            break;
+    case 19:
+        gly = "#(233)"; // #
+        break;
 
-        case 20:
-            gly = "#(850)"; // filled circle
-            break;
+    case 20:
+        gly = "#(850)"; // filled circle
+        break;
 
-        case 21:
-            gly = "#(844)"; // unfilled star
-            break;
+    case 21:
+        gly = "#(844)"; // unfilled star
+        break;
 
-        case 22:
-            gly = "#(843)"; // unfilled diamond
-            break;
+    case 22:
+        gly = "#(843)"; // unfilled diamond
+        break;
 
-        case 23:
-            gly = "#(842)"; // unfilled triangle
-            break;
+    case 23:
+        gly = "#(842)"; // unfilled triangle
+        break;
 
-        case 24:
-            gly = "#(841)"; // big square
-            break;
+    case 24:
+        gly = "#(841)"; // big square
+        break;
 
-        case 25:
-            gly = "#(2367)"; // .
-            break;
+    case 25:
+        gly = "#(2367)"; // .
+        break;
 
-        default:
-            gly = "#(856)"; // star
+    default:
+        gly = "#(856)"; // star
     }
 }
 
-template <typename T> EXPORTGTPLPLOT
-bool plotCurves(const std::vector<hoNDArray<T> >& x, const std::vector<hoNDArray<T> >& y,
-    const std::string& xlabel, const std::string& ylabel,
-    const std::string& title, const std::vector<std::string>& legend,
-    const std::vector<std::string>& symbols,
-    size_t xsize, size_t ysize,
-    bool trueColor, bool drawLine,
-    hoNDArray<float>& plotIm)
-{
-    try
-    {
-        GADGET_CHECK_RETURN_FALSE(x.size()>0);
-        GADGET_CHECK_RETURN_FALSE(y.size()>0);
+template <typename T>
+EXPORTGTPLPLOT bool
+plotCurves(const std::vector<hoNDArray<T>>& x, const std::vector<hoNDArray<T>>& y, const std::string& xlabel,
+           const std::string& ylabel, const std::string& title, const std::vector<std::string>& legend,
+           const std::vector<std::string>& symbols, size_t xsize, size_t ysize, bool trueColor, bool drawLine,
+           const std::vector<int>& lineStyple, const std::vector<int>& lineWidth, hoNDArray<float>& plotIm) {
+    try {
+        GADGET_CHECK_RETURN_FALSE(x.size() > 0);
+        GADGET_CHECK_RETURN_FALSE(y.size() > 0);
         GADGET_CHECK_RETURN_FALSE(x.size() == y.size());
 
         T xlim[2], ylim[2];
         findDataRange(x, y, xlim[0], xlim[1], ylim[0], ylim[1]);
 
-        return Gadgetron::plotCurves(x, y, xlabel, ylabel, title, legend, symbols, xsize, ysize, xlim, ylim, trueColor, drawLine, plotIm);
-    }
-    catch(...)
-    {
+        return Gadgetron::plotCurves(x, y, xlabel, ylabel, title, legend, symbols, xsize, ysize, xlim, ylim, trueColor,
+                                     drawLine, lineStyple, lineWidth, plotIm);
+    } catch (...) {
         GERROR_STREAM("Errors happened in plotCurves(...) ... ");
         return false;
     }
@@ -300,26 +289,29 @@ bool plotCurves(const std::vector<hoNDArray<T> >& x, const std::vector<hoNDArray
     return true;
 }
 
-template EXPORTGTPLPLOT bool plotCurves(const std::vector<hoNDArray<float> >& x, const std::vector<hoNDArray<float> >& y, const std::string& xlabel, const std::string& ylabel, const std::string& title, const std::vector<std::string>& legend, const std::vector<std::string>& symbols, 
-    size_t xsize, size_t ysize, bool trueColor, bool drawLine, hoNDArray<float>& plotIm);
+template EXPORTGTPLPLOT bool plotCurves(const std::vector<hoNDArray<float>>& x, const std::vector<hoNDArray<float>>& y,
+                                        const std::string& xlabel, const std::string& ylabel, const std::string& title,
+                                        const std::vector<std::string>& legend, const std::vector<std::string>& symbols,
+                                        size_t xsize, size_t ysize, bool trueColor, bool drawLine,
+                                        const std::vector<int>& lineStyple, const std::vector<int>& lineWidth,
+                                        hoNDArray<float>& plotIm);
 
-template EXPORTGTPLPLOT bool plotCurves(const std::vector<hoNDArray<double> >& x, const std::vector<hoNDArray<double> >& y, const std::string& xlabel, const std::string& ylabel, const std::string& title, const std::vector<std::string>& legend, const std::vector<std::string>& symbols, 
-    size_t xsize, size_t ysize, bool trueColor, bool drawLine, hoNDArray<float>& plotIm);
+template EXPORTGTPLPLOT bool
+plotCurves(const std::vector<hoNDArray<double>>& x, const std::vector<hoNDArray<double>>& y, const std::string& xlabel,
+           const std::string& ylabel, const std::string& title, const std::vector<std::string>& legend,
+           const std::vector<std::string>& symbols, size_t xsize, size_t ysize, bool trueColor, bool drawLine,
+           const std::vector<int>& lineStyple, const std::vector<int>& lineWidth, hoNDArray<float>& plotIm);
 
-template <typename T> EXPORTGTPLPLOT
-bool plotCurves(const std::vector<hoNDArray<T> >& x, const std::vector<hoNDArray<T> >& y, 
-                const std::string& xlabel, const std::string& ylabel, 
-                const std::string& title, const std::vector<std::string>& legend, 
-                const std::vector<std::string>& symbols, 
-                size_t xsize, size_t ysize, 
-                T xlim[2], T ylim[2], 
-                bool trueColor, bool drawLine, 
-                hoNDArray<float>& plotIm)
-{
-    try
-    {
-        GADGET_CHECK_RETURN_FALSE(x.size()>0);
-        GADGET_CHECK_RETURN_FALSE(y.size()>0);
+template <typename T>
+EXPORTGTPLPLOT bool plotCurves(const std::vector<hoNDArray<T>>& x, const std::vector<hoNDArray<T>>& y,
+                               const std::string& xlabel, const std::string& ylabel, const std::string& title,
+                               const std::vector<std::string>& legend, const std::vector<std::string>& symbols,
+                               size_t xsize, size_t ysize, T xlim[2], T ylim[2], bool trueColor, bool drawLine,
+                               const std::vector<int>& lineStyple, const std::vector<int>& lineWidth,
+                               hoNDArray<float>& plotIm) {
+    try {
+        GADGET_CHECK_RETURN_FALSE(x.size() > 0);
+        GADGET_CHECK_RETURN_FALSE(y.size() > 0);
         GADGET_CHECK_RETURN_FALSE(x.size() == y.size());
 
         T minX = xlim[0];
@@ -340,28 +332,29 @@ bool plotCurves(const std::vector<hoNDArray<T> >& x, const std::vector<hoNDArray
 
         pladv(0);
 
-        if (legend.size() == x.size())
-        {
+        if (legend.size() == x.size()) {
             plvpor(0.11, 0.75, 0.1, 0.9);
-        }
-        else
-        {
+        } else {
             plvpor(0.15, 0.85, 0.1, 0.9);
         }
 
-        T spaceX = 0.01*(maxX - minX);
+        /*T spaceX = 0.01*(maxX - minX);
         T spaceY = 0.05*(maxY - minY);
+        plwind(minX - spaceX, maxX + spaceX, minY - spaceY, maxY + spaceY);*/
 
-        plwind(minX - spaceX, maxX + spaceX, minY - spaceY, maxY + spaceY);
+        plvsta();
+        plwind(minX, maxX, minY, maxY);
+        plsmaj(0.0, 0.0);
+        plsmin(0.0, 0.0);
 
         plcol0(15);
         plbox("bgcnst", 0.0, 0, "bgcnstv", 0.0, 0);
 
         // int mark[2], space[2];
 
-        //mark[0] = 4000;
-        //space[0] = 2500;
-        //plstyl(1, mark, space);
+        // mark[0] = 4000;
+        // space[0] = 2500;
+        // plstyl(1, mark, space);
 
         size_t num = x.size();
 
@@ -370,31 +363,31 @@ bool plotCurves(const std::vector<hoNDArray<T> >& x, const std::vector<hoNDArray
         hoNDArray<double> xd, yd;
 
         // draw lines
-        for (n = 0; n < num; n++)
-        {
+        for (n = 0; n < num; n++) {
             size_t N = y[n].get_size(0);
 
             xd.copyFrom(x[n]);
             yd.copyFrom(y[n]);
 
-            if (drawLine)
-            {
+            if (drawLine) {
                 int c;
                 getPlotColor(n, c);
                 plcol0(c);
-                pllsty(n % 8 + 1);
+                if (lineStyple.size() > n) {
+                    pllsty(lineStyple[n]);
+                    plwidth(lineWidth[n]);
+                } else {
+                    pllsty(1);
+                    plwidth(2);
+                }
                 plline(N, xd.begin(), yd.begin());
             }
 
             std::string gly;
-            if(symbols.size()>n)
-            {
+            if (symbols.size() > n) {
                 gly = symbols[n];
+                plstring(N, xd.begin(), yd.begin(), gly.c_str());
             }
-            else
-                getPlotGlyph(n, gly);
-
-            plstring(N, xd.begin(), yd.begin(), gly.c_str());
         }
 
         plcol0(15);
@@ -403,19 +396,18 @@ bool plotCurves(const std::vector<hoNDArray<T> >& x, const std::vector<hoNDArray
         plmtex("l", 5.0, 0.5, 0.5, ylabel.c_str());
 
         // draw the legend
-        if (legend.size() == x.size())
-        {
-            std::vector<PLINT> opt_array(num), text_colors(num), line_colors(num), line_styles(num), symbol_numbers(num), symbol_colors(num);
+        if (legend.size() == x.size()) {
+            std::vector<PLINT> opt_array(num), text_colors(num), line_colors(num), line_styles(num),
+                symbol_numbers(num), symbol_colors(num);
             std::vector<PLFLT> symbol_scales(num), line_widths(num), box_scales(num, 1);
 
             std::vector<std::string> glyphs(num);
-            std::vector<const char*> symbols(num);
+            std::vector<const char*> syms;
             PLFLT legend_width, legend_height;
 
             std::vector<const char*> legend_text(num);
 
-            for (n = 0; n < num; n++)
-            {
+            for (n = 0; n < num; n++) {
                 int c;
                 getPlotColor(n, c);
                 getPlotGlyph(n, glyphs[n]);
@@ -423,55 +415,57 @@ bool plotCurves(const std::vector<hoNDArray<T> >& x, const std::vector<hoNDArray
                 opt_array[n] = PL_LEGEND_SYMBOL | PL_LEGEND_LINE;
                 text_colors[n] = 15;
                 line_colors[n] = c;
-                line_styles[n] = (n%8+1);
-                line_widths[n] = 0.2;
+
+                if (lineStyple.size() > n)
+                    line_styles[n] = lineStyple[n];
+                else
+                    line_styles[n] = 1;
+
+                line_widths[n] = 0.4;
                 symbol_colors[n] = c;
                 symbol_scales[n] = 0.75;
                 symbol_numbers[n] = 1;
-                symbols[n] = glyphs[n].c_str();
+
+                if (symbols.size() > n) {
+                    syms.push_back(symbols[n].c_str());
+                } else {
+                    syms.push_back("");
+                }
                 legend_text[n] = legend[n].c_str();
             }
 
-            pllegend(&legend_width, 
-                    &legend_height,
-                    PL_LEGEND_BACKGROUND,
-                    PL_POSITION_OUTSIDE | PL_POSITION_RIGHT | PL_POSITION_TOP,
-                    0.02,                                       // x
-                    0.0,                                        // y
-                    0.05,                                       // plot_width
-                    0,                                          // bg_color
-                    15,                                         // bb_color
-                    1,                                          // bb_style
-                    0,                                          // nrow
-                    0,                                          // ncolumn
-                    num,                                        // nlegend
-                    &opt_array[0], 
-                    0.05,                                       // text_offset
-                    0.35,                                       // text_scale
-                    1.0,                                        // text_spacing
-                    0.5,                                        // text_justification
-                    &text_colors[0], 
-                    (const char **)(&legend_text[0]), 
-                    NULL,                                       // box_colors
-                    NULL,                                       // box_patterns
-                    &box_scales[0],                             // box_scales
-                    NULL,                                       // box_line_widths
-                    &line_colors[0], 
-                    &line_styles[0], 
-                    &line_widths[0],
-                    &symbol_colors[0], 
-                    &symbol_scales[0], 
-                    &symbol_numbers[0], 
-                    (const char **)(&symbols[0])
-                    );
+            pllegend(&legend_width, &legend_height, PL_LEGEND_BACKGROUND,
+                     PL_POSITION_OUTSIDE | PL_POSITION_RIGHT | PL_POSITION_TOP,
+                     0.02, // x
+                     0.0,  // y
+                     0.05, // plot_width
+                     0,    // bg_color
+                     15,   // bb_color
+                     1,    // bb_style
+                     0,    // nrow
+                     0,    // ncolumn
+                     num,  // nlegend
+                     &opt_array[0],
+                     0.05, // text_offset
+                     0.35, // text_scale
+                     1.0,  // text_spacing
+                     0.5,  // text_justification
+                     &text_colors[0], (const char**)(&legend_text[0]),
+                     NULL,           // box_colors
+                     NULL,           // box_patterns
+                     &box_scales[0], // box_scales
+                     NULL,           // box_line_widths
+                     &line_colors[0], &line_styles[0], &line_widths[0], &symbol_colors[0], &symbol_scales[0],
+                     &symbol_numbers[0], (const char**)(&syms[0]));
         }
+
+        plsmin(0.0, 1.0);
+        plsmaj(0.0, 1.0);
 
         plend();
 
         outputPlotIm(im, trueColor, plotIm);
-    }
-    catch (...)
-    {
+    } catch (...) {
         GERROR_STREAM("Errors happened in plotCurves(xlim, ylim) ... ");
         return false;
     }
@@ -479,22 +473,28 @@ bool plotCurves(const std::vector<hoNDArray<T> >& x, const std::vector<hoNDArray
     return true;
 }
 
-template EXPORTGTPLPLOT bool plotCurves(const std::vector<hoNDArray<float> >& x, const std::vector<hoNDArray<float> >& y, const std::string& xlabel, const std::string& ylabel, const std::string& title, const std::vector<std::string>& legend, const std::vector<std::string>& symbols, 
-    size_t xsize, size_t ysize, float xlim[2], float ylim[2], bool trueColor, bool drawLine, hoNDArray<float>& plotIm);
+template EXPORTGTPLPLOT bool plotCurves(const std::vector<hoNDArray<float>>& x, const std::vector<hoNDArray<float>>& y,
+                                        const std::string& xlabel, const std::string& ylabel, const std::string& title,
+                                        const std::vector<std::string>& legend, const std::vector<std::string>& symbols,
+                                        size_t xsize, size_t ysize, float xlim[2], float ylim[2], bool trueColor,
+                                        bool drawLine, const std::vector<int>& lineStyple,
+                                        const std::vector<int>& lineWidth, hoNDArray<float>& plotIm);
 
-template EXPORTGTPLPLOT bool plotCurves(const std::vector<hoNDArray<double> >& x, const std::vector<hoNDArray<double> >& y, const std::string& xlabel, const std::string& ylabel, const std::string& title, const std::vector<std::string>& legend, const std::vector<std::string>& symbols, 
-    size_t xsize, size_t ysize, double xlim[2], double ylim[2], bool trueColor, bool drawLine, hoNDArray<float>& plotIm);
+template EXPORTGTPLPLOT bool plotCurves(const std::vector<hoNDArray<double>>& x,
+                                        const std::vector<hoNDArray<double>>& y, const std::string& xlabel,
+                                        const std::string& ylabel, const std::string& title,
+                                        const std::vector<std::string>& legend, const std::vector<std::string>& symbols,
+                                        size_t xsize, size_t ysize, double xlim[2], double ylim[2], bool trueColor,
+                                        bool drawLine, const std::vector<int>& lineStyple,
+                                        const std::vector<int>& lineWidth, hoNDArray<float>& plotIm);
 
 // ---------------------------------------------------
 
-template <typename T> 
-bool plotNoiseStandardDeviation(const hoNDArray< std::complex<T> >& m, const std::vector<std::string>& coilStrings,
-                    const std::string& xlabel, const std::string& ylabel, const std::string& title,
-                    size_t xsize, size_t ysize, bool trueColor,
-                    hoNDArray<float>& plotIm)
-{
-    try
-    {
+template <typename T>
+bool plotNoiseStandardDeviation(const hoNDArray<std::complex<T>>& m, const std::vector<std::string>& coilStrings,
+                                const std::string& xlabel, const std::string& ylabel, const std::string& title,
+                                size_t xsize, size_t ysize, bool trueColor, hoNDArray<float>& plotIm) {
+    try {
         size_t CHA = m.get_size(0);
         GADGET_CHECK_RETURN_FALSE(coilStrings.size() == CHA);
 
@@ -504,10 +504,9 @@ bool plotNoiseStandardDeviation(const hoNDArray< std::complex<T> >& m, const std
         yd.create(CHA);
 
         size_t c;
-        for (c = 0; c < CHA; c++)
-        {
-            xd(c) = c+1;
-            yd(c) = std::sqrt( std::abs(m(c, c)) );
+        for (c = 0; c < CHA; c++) {
+            xd(c) = c + 1;
+            yd(c) = std::sqrt(std::abs(m(c, c)));
         }
 
         double maxY = Gadgetron::max(&yd);
@@ -519,9 +518,8 @@ bool plotNoiseStandardDeviation(const hoNDArray< std::complex<T> >& m, const std
         // increase dot line to be 1 sigma ~= 33%
         double medRange = 0.33;
 
-        if (maxY < medY*(1 + medRange))
-        {
-            maxY = medY*(1 + medRange);
+        if (maxY < medY * (1 + medRange)) {
+            maxY = medY * (1 + medRange);
         }
 
         hoNDArray<unsigned char> im;
@@ -537,7 +535,7 @@ bool plotNoiseStandardDeviation(const hoNDArray< std::complex<T> >& m, const std
         pladv(0);
         plvpor(0.15, 0.75, 0.1, 0.8);
 
-        plwind(0, CHA+1, 0, maxY*1.05);
+        plwind(0, CHA + 1, 0, maxY * 1.05);
 
         plcol0(15);
         plbox("bcnst", 0.0, 0, "bcnstv", 0.0, 0);
@@ -552,7 +550,7 @@ bool plotNoiseStandardDeviation(const hoNDArray< std::complex<T> >& m, const std
         double px[2], py[2];
 
         px[0] = 0;
-        px[1] = CHA+1;
+        px[1] = CHA + 1;
 
         py[0] = medY;
         py[1] = medY;
@@ -561,13 +559,13 @@ bool plotNoiseStandardDeviation(const hoNDArray< std::complex<T> >& m, const std
 
         pllsty(2);
 
-        py[0] = medY*(1 - medRange);
-        py[1] = medY*(1 - medRange);
+        py[0] = medY * (1 - medRange);
+        py[1] = medY * (1 - medRange);
 
         plline(2, px, py);
 
-        py[0] = medY*(1 + medRange);
-        py[1] = medY*(1 + medRange);
+        py[0] = medY * (1 + medRange);
+        py[1] = medY * (1 + medRange);
 
         plline(2, px, py);
 
@@ -576,7 +574,8 @@ bool plotNoiseStandardDeviation(const hoNDArray< std::complex<T> >& m, const std
         plmtex("l", 5.0, 0.5, 0.5, ylabel.c_str());
 
         // draw the legend
-        std::vector<PLINT> opt_array(CHA), text_colors(CHA), line_colors(CHA), line_styles(CHA), symbol_numbers(CHA), symbol_colors(CHA);
+        std::vector<PLINT> opt_array(CHA), text_colors(CHA), line_colors(CHA), line_styles(CHA), symbol_numbers(CHA),
+            symbol_colors(CHA);
         std::vector<PLFLT> symbol_scales(CHA), line_widths(CHA), box_scales(CHA, 1);
 
         std::vector<const char*> symbols(CHA);
@@ -587,8 +586,7 @@ bool plotNoiseStandardDeviation(const hoNDArray< std::complex<T> >& m, const std
         std::vector<std::string> legends(CHA);
 
         size_t n;
-        for (n = 0; n < CHA; n++)
-        {
+        for (n = 0; n < CHA; n++) {
             opt_array[n] = PL_LEGEND_SYMBOL;
             text_colors[n] = 15;
             line_colors[n] = 15;
@@ -600,52 +598,40 @@ bool plotNoiseStandardDeviation(const hoNDArray< std::complex<T> >& m, const std
             symbols[n] = gly.c_str();
 
             std::ostringstream ostr;
-            ostr << n+1 << ":" << coilStrings[n];
+            ostr << n + 1 << ":" << coilStrings[n];
 
             legends[n] = ostr.str();
 
             legend_text[n] = legends[n].c_str();
         }
 
-        pllegend(&legend_width,
-            &legend_height,
-            PL_LEGEND_BACKGROUND,
-            PL_POSITION_OUTSIDE | PL_POSITION_RIGHT,
-            0.02,                                       // x
-            0.0,                                        // y
-            0.05,                                       // plot_width
-            0,                                          // bg_color
-            15,                                         // bb_color
-            1,                                          // bb_style
-            0,                                          // nrow
-            0,                                          // ncolumn
-            CHA,                                        // nlegend
-            &opt_array[0],
-            0.05,                                       // text_offset
-            0.5,                                        // text_scale
-            1.0,                                        // text_spacing
-            0.5,                                        // text_justification
-            &text_colors[0],
-            (const char **)(&legend_text[0]),
-            NULL,                                       // box_colors
-            NULL,                                       // box_patterns
-            &box_scales[0],                             // box_scales
-            NULL,                                       // box_line_widths
-            &line_colors[0],
-            &line_styles[0],
-            &line_widths[0],
-            &symbol_colors[0],
-            &symbol_scales[0],
-            &symbol_numbers[0],
-            (const char **)(&symbols[0])
-            );
+        pllegend(&legend_width, &legend_height, PL_LEGEND_BACKGROUND, PL_POSITION_OUTSIDE | PL_POSITION_RIGHT,
+                 0.02, // x
+                 0.0,  // y
+                 0.05, // plot_width
+                 0,    // bg_color
+                 15,   // bb_color
+                 1,    // bb_style
+                 0,    // nrow
+                 0,    // ncolumn
+                 CHA,  // nlegend
+                 &opt_array[0],
+                 0.05, // text_offset
+                 0.5,  // text_scale
+                 1.0,  // text_spacing
+                 0.5,  // text_justification
+                 &text_colors[0], (const char**)(&legend_text[0]),
+                 NULL,           // box_colors
+                 NULL,           // box_patterns
+                 &box_scales[0], // box_scales
+                 NULL,           // box_line_widths
+                 &line_colors[0], &line_styles[0], &line_widths[0], &symbol_colors[0], &symbol_scales[0],
+                 &symbol_numbers[0], (const char**)(&symbols[0]));
 
         plend();
 
         outputPlotIm(im, trueColor, plotIm);
-    }
-    catch (...)
-    {
+    } catch (...) {
         GERROR_STREAM("Errors happened in plotNoiseStandardDeviation(...) ... ");
         return false;
     }
@@ -653,10 +639,16 @@ bool plotNoiseStandardDeviation(const hoNDArray< std::complex<T> >& m, const std
     return true;
 }
 
-template EXPORTGTPLPLOT bool plotNoiseStandardDeviation(const hoNDArray< std::complex<float> >& m, const std::vector<std::string>& coilStrings,
-    const std::string& xlabel, const std::string& ylabel, const std::string& title, size_t xsize, size_t ysize, bool trueColor, hoNDArray<float>& plotIm);
+template EXPORTGTPLPLOT bool plotNoiseStandardDeviation(const hoNDArray<std::complex<float>>& m,
+                                                        const std::vector<std::string>& coilStrings,
+                                                        const std::string& xlabel, const std::string& ylabel,
+                                                        const std::string& title, size_t xsize, size_t ysize,
+                                                        bool trueColor, hoNDArray<float>& plotIm);
 
-template EXPORTGTPLPLOT bool plotNoiseStandardDeviation(const hoNDArray< std::complex<double> >& m, const std::vector<std::string>& coilStrings,
-    const std::string& xlabel, const std::string& ylabel, const std::string& title, size_t xsize, size_t ysize, bool trueColor, hoNDArray<float>& plotIm);
+template EXPORTGTPLPLOT bool plotNoiseStandardDeviation(const hoNDArray<std::complex<double>>& m,
+                                                        const std::vector<std::string>& coilStrings,
+                                                        const std::string& xlabel, const std::string& ylabel,
+                                                        const std::string& title, size_t xsize, size_t ysize,
+                                                        bool trueColor, hoNDArray<float>& plotIm);
 
-}
+} // namespace Gadgetron

--- a/toolboxes/plplot/GtPLplot.h
+++ b/toolboxes/plplot/GtPLplot.h
@@ -12,35 +12,44 @@
 #include "PLplotExport.h"
 
 #include "hoNDArray_elemwise.h"
-#include "hoNDArray_utils.h"
 #include "hoNDArray_reductions.h"
+#include "hoNDArray_utils.h"
 
-namespace Gadgetron
-{
-    /// plot 1D hoNDArray as curves
-    /// x: x coordinate of 1D curve
-    /// y: values of 1D curve
-    /// xlabel, ylabel: x and y label strings
-    /// title: title string
-    /// legend: legend string for every curve, if empty, no legends will be plotted
-    /// xsize, ysize: the plotted image size
-    /// plotIm: the plotted image, if trueColor = true, [xsize ysize 3] array
-    /// if trueColor = false, the grey image will be generated [xsize ysize]
-    /// if drawLine = false, the line will be not plotted, onl glyphs
-    template <typename T> EXPORTGTPLPLOT
-    bool plotCurves(const std::vector<hoNDArray<T> >& x, const std::vector<hoNDArray<T> >& y, const std::string& xlabel, const std::string& ylabel, const std::string& title, const std::vector<std::string>& legend, const std::vector<std::string>& symbols, 
-        size_t xsize, size_t ysize, bool trueColor, bool drawLine, hoNDArray<float>& plotIm);
+namespace Gadgetron {
+/// plot 1D hoNDArray as curves
+/// x: x coordinate of 1D curve
+/// y: values of 1D curve
+/// xlabel, ylabel: x and y label strings
+/// title: title string
+/// legend: legend string for every curve, if empty, no legends will be plotted
+/// xsize, ysize: the plotted image size
+/// plotIm: the plotted image, if trueColor = true, [xsize ysize 3] array
+/// if trueColor = false, the grey image will be generated [xsize ysize]
+/// if drawLine = false, the line will be not plotted, onl glyphs
+template <typename T>
+EXPORTGTPLPLOT bool
+plotCurves(const std::vector<hoNDArray<T>>& x, const std::vector<hoNDArray<T>>& y, const std::string& xlabel,
+           const std::string& ylabel, const std::string& title, const std::vector<std::string>& legend,
+           const std::vector<std::string>& symbols, size_t xsize, size_t ysize, bool trueColor, bool drawLine,
+           const std::vector<int>& lineStyple, const std::vector<int>& lineWidth, hoNDArray<float>& plotIm);
 
-    /// user can supply x/y axis limits to plot
-    /// xlim: xmin to xmax
-    /// ylim: ymin to ymax
-    template <typename T> EXPORTGTPLPLOT
-        bool plotCurves(const std::vector<hoNDArray<T> >& x, const std::vector<hoNDArray<T> >& y, const std::string& xlabel, const std::string& ylabel, const std::string& title, const std::vector<std::string>& legend, const std::vector<std::string>& symbols, 
-            size_t xsize, size_t ysize, T xlim[2], T ylim[2], bool trueColor, bool drawLine, hoNDArray<float>& plotIm);
+/// user can supply x/y axis limits to plot
+/// xlim: xmin to xmax
+/// ylim: ymin to ymax
+template <typename T>
+EXPORTGTPLPLOT bool plotCurves(const std::vector<hoNDArray<T>>& x, const std::vector<hoNDArray<T>>& y,
+                               const std::string& xlabel, const std::string& ylabel, const std::string& title,
+                               const std::vector<std::string>& legend, const std::vector<std::string>& symbols,
+                               size_t xsize, size_t ysize, T xlim[2], T ylim[2], bool trueColor, bool drawLine,
+                               const std::vector<int>& lineStyple, const std::vector<int>& lineWidth,
+                               hoNDArray<float>& plotIm);
 
-    /// plot noise std
-    template <typename T> EXPORTGTPLPLOT
-    bool plotNoiseStandardDeviation(const hoNDArray< std::complex<T> >& m, const std::vector<std::string>& coilStrings, const std::string& xlabel, const std::string& ylabel, const std::string& title, size_t xsize, size_t ysize, bool trueColor, hoNDArray<float>& plotIm);
-}
+/// plot noise std
+template <typename T>
+EXPORTGTPLPLOT bool plotNoiseStandardDeviation(const hoNDArray<std::complex<T>>& m,
+                                               const std::vector<std::string>& coilStrings, const std::string& xlabel,
+                                               const std::string& ylabel, const std::string& title, size_t xsize,
+                                               size_t ysize, bool trueColor, hoNDArray<float>& plotIm);
+} // namespace Gadgetron
 
 #endif // GT_PLPLOT_H


### PR DESCRIPTION
Just submitting this draft for comments.

siemens_to_ismrmrd accepts only one of the -x or --user-stylesheet options so the logic here is:

"Remove the -x option and its argument, and add in the --user-stylesheet option and its argument, if specified."

To minimise the number Python lines my (Python novice) fingers might damage I have (ab)used the data_conversion_flag test parameter to pass in the --user-stylesheet option and argument. Note the line to add in the .cfg file has to use a second "=" as a separator and not [space] to be passed unmolested by Python to siemens_to_ismrmrd.

`data_conversion_flag=--user-stylesheet=filename.xml`

The alternative, more elegant but involving somewhat more coding, would seem be adding a new parameter:

`user_parameter_xsl=filename.xml`