### PR TITLE
Boost process stdin fix

### DIFF
--- a/apps/gadgetron/connection/nodes/external/Matlab.cpp
+++ b/apps/gadgetron/connection/nodes/external/Matlab.cpp
@@ -22,7 +22,8 @@ namespace Gadgetron::Server::Connection::Nodes {
         auto module = Process::child(
                 boost::process::search_path("matlab"),
                 boost::process::args={"-batch", "gadgetron.external.main"},
-                env,
+                env
+//                ,
 //                boost::process::limit_handles,
 //                boost::process::std_out > stdout,
 //                boost::process::std_err > stderr

--- a/apps/gadgetron/connection/nodes/external/Matlab.cpp
+++ b/apps/gadgetron/connection/nodes/external/Matlab.cpp
@@ -23,9 +23,9 @@ namespace Gadgetron::Server::Connection::Nodes {
                 boost::process::search_path("matlab"),
                 boost::process::args={"-batch", "gadgetron.external.main"},
                 env,
-                boost::process::limit_handles,
-                boost::process::std_out > stdout,
-                boost::process::std_err > stderr
+//                boost::process::limit_handles,
+//                boost::process::std_out > stdout,
+//                boost::process::std_err > stderr
         );
 
         GINFO_STREAM("Started external MATLAB module (pid: " << module.id() << ").");


### PR DESCRIPTION
Fixes a bug where Matlab could crash because it had no defined stdin when being called by Gadgetron.